### PR TITLE
Richer node and price-only UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### Improvements
 
 - Price and fee panels keep the last good value when a refresh fails and show `STALE` or `ERR` instead of going blank.
+- Node views show glanceable facts: Core peers/mempool/disk/sync, compact Lightning channel rows. Price-only adds a sparkline and session high/low.

--- a/src/app.rs
+++ b/src/app.rs
@@ -321,6 +321,9 @@ impl App {
         if state.last_price_in_currency.is_none() {
             state.last_price_in_currency = self.state.price.last_price_in_currency;
         }
+        if state.last_ok_at.is_none() {
+            state.last_ok_at = self.state.price.last_ok_at;
+        }
         let record_history = state.last_error.is_none();
         self.state.price = state;
         if !record_history {
@@ -623,11 +626,13 @@ mod tests {
             currency: PriceCurrency::USD,
             last_price_in_currency: Some(100_000.0),
             last_error: None,
+            last_ok_at: None,
         });
         app.handle_price_update(PriceState {
             currency: PriceCurrency::USD,
             last_price_in_currency: None,
             last_error: Some("connection reset".to_string()),
+            last_ok_at: None,
         });
 
         assert_eq!(app.state.price.last_price_in_currency, Some(100_000.0));

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,109 @@
+pub fn commas(value: u64) -> String {
+    let raw = value.to_string();
+    let mut out = String::new();
+    for (index, ch) in raw.chars().rev().enumerate() {
+        if index > 0 && index % 3 == 0 {
+            out.push(',');
+        }
+        out.push(ch);
+    }
+    out.chars().rev().collect()
+}
+
+pub fn short_hash(hash: &str) -> String {
+    let chars: Vec<char> = hash.chars().collect();
+    if chars.len() <= 17 {
+        return hash.to_string();
+    }
+    format!(
+        "{}…{}",
+        chars.iter().take(8).collect::<String>(),
+        chars.iter().rev().take(8).rev().collect::<String>()
+    )
+}
+
+pub fn bytes_compact(bytes: u64) -> String {
+    const GIB: u64 = 1024 * 1024 * 1024;
+    const MIB: u64 = 1024 * 1024;
+    if bytes >= GIB {
+        format!("{} GB", commas(bytes / GIB))
+    } else if bytes >= MIB {
+        format!("{} MB", commas(bytes / MIB))
+    } else {
+        format!("{} B", commas(bytes))
+    }
+}
+
+pub fn sparkline(values: &[f64], width: usize) -> String {
+    const BARS: [char; 8] = ['▁', '▂', '▃', '▄', '▅', '▆', '▇', '█'];
+    if width == 0 || values.is_empty() {
+        return String::new();
+    }
+
+    let min = values.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let span = max - min;
+
+    (0..width)
+        .map(|column| {
+            let index = if width == 1 {
+                values.len() - 1
+            } else {
+                column * (values.len() - 1) / (width - 1)
+            };
+            let value = values[index];
+            if !value.is_finite() {
+                return ' ';
+            }
+            let rank = if span <= f64::EPSILON {
+                4
+            } else {
+                (((value - min) / span) * 7.0).round() as usize
+            };
+            BARS[rank.min(7)]
+        })
+        .collect()
+}
+
+pub fn chain_label(chain: &str) -> &str {
+    match chain {
+        "bitcoin" | "main" => "main",
+        "testnet" | "test" => "test",
+        "testnet4" => "test4",
+        "signet" => "signet",
+        "regtest" => "regtest",
+        other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bytes_compact, commas, short_hash, sparkline};
+
+    #[test]
+    fn commas_groups_thousands() {
+        assert_eq!(commas(109_432), "109,432");
+        assert_eq!(commas(12), "12");
+    }
+
+    #[test]
+    fn short_hash_keeps_head_and_tail() {
+        assert_eq!(
+            short_hash("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+            "01234567…89abcdef"
+        );
+        assert_eq!(short_hash("abc"), "abc");
+    }
+
+    #[test]
+    fn sparkline_is_the_requested_width() {
+        let line = sparkline(&[1.0, 2.0, 3.0, 2.5], 8);
+        assert_eq!(line.chars().count(), 8);
+        assert!(line.chars().all(|ch| "▁▂▃▄▅▆▇█".contains(ch)));
+    }
+
+    #[test]
+    fn bytes_compact_uses_gb_for_chainstate() {
+        assert_eq!(bytes_compact(687 * 1024 * 1024 * 1024), "687 GB");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,3 +23,5 @@ pub mod node;
 pub mod fees;
 
 pub mod widget;
+
+pub mod format;

--- a/src/node/providers/bitcoin_core.rs
+++ b/src/node/providers/bitcoin_core.rs
@@ -38,6 +38,12 @@ pub struct BitcoinCoreWidgetState {
     pub title: String,
     pub headers: u64,
     pub last_hash: String,
+    pub chain: String,
+    pub peers: u64,
+    pub mempool_tx: u64,
+    pub size_on_disk: u64,
+    pub verification_progress: f64,
+    pub pruned: bool,
 }
 
 impl DynamicState for BitcoinCoreWidgetState {
@@ -71,25 +77,87 @@ impl DynamicNodeStatefulWidget for BitcoinCoreWidget {
 
         let block_height = match node_state.status {
             NodeStatus::Synchronizing => Line::from(vec![
-                Span::raw("Block Height: "),
-                Span::styled(node_state.height.to_string(), Style::new().fg(Color::White)),
+                Span::raw("Height: "),
+                Span::styled(
+                    crate::format::commas(node_state.height),
+                    Style::new().fg(Color::White),
+                ),
                 Span::raw("/"),
-                Span::styled(state.headers.to_string(), Style::new().fg(Color::Blue)),
+                Span::styled(
+                    crate::format::commas(state.headers),
+                    Style::new().fg(Color::Blue),
+                ),
             ]),
             _ => Line::from(vec![
-                Span::raw("Block Height: "),
-                Span::styled(node_state.height.to_string(), Style::new().fg(Color::White)),
+                Span::raw("Height: "),
+                Span::styled(
+                    crate::format::commas(node_state.height),
+                    Style::new().fg(Color::White),
+                ),
             ]),
         };
 
-        let lines = vec![
+        let sync_pct = (state.verification_progress * 100.0).clamp(0.0, 100.0);
+        let network = if state.peers == 0 {
+            crate::format::chain_label(&state.chain).to_string()
+        } else {
+            format!(
+                "{} · {} peers",
+                crate::format::chain_label(&state.chain),
+                crate::format::commas(state.peers)
+            )
+        };
+        let mut lines = vec![
             block_height,
             Line::from(vec![
-                Span::raw("Last Block: "),
-                Span::styled(state.last_hash.clone(), Style::new().fg(Color::White)),
+                Span::raw("Tip: "),
+                Span::styled(
+                    crate::format::short_hash(&state.last_hash),
+                    Style::new().fg(Color::White),
+                ),
             ]),
-            Line::raw("------"),
+            Line::from(vec![
+                Span::raw("Network: "),
+                Span::styled(network, Style::new().fg(Color::White)),
+            ]),
+            Line::from(vec![
+                Span::raw("Mempool: "),
+                Span::styled(
+                    format!("{} tx", crate::format::commas(state.mempool_tx)),
+                    Style::new().fg(Color::White),
+                ),
+            ]),
+            Line::from(vec![
+                Span::raw("Disk: "),
+                Span::styled(
+                    crate::format::bytes_compact(state.size_on_disk),
+                    Style::new().fg(Color::White),
+                ),
+            ]),
+            Line::from(vec![
+                Span::raw("Sync: "),
+                Span::styled(
+                    if state.pruned {
+                        format!("{sync_pct:.0}% · pruned")
+                    } else {
+                        format!("{sync_pct:.0}%")
+                    },
+                    Style::new().fg(Color::White),
+                ),
+            ]),
         ];
+        if node_state.status == NodeStatus::Synchronizing {
+            lines.insert(
+                1,
+                Line::from(vec![
+                    Span::raw("Headers: "),
+                    Span::styled(
+                        crate::format::commas(state.headers),
+                        Style::new().fg(Color::Blue),
+                    ),
+                ]),
+            );
+        }
 
         let widget = BlockedParagraph::new(&state.title, node_state.status, lines);
         widget.render(area, buf);
@@ -171,6 +239,16 @@ impl BitcoinCore {
 
         match self.rpc_client.get_blockchain_info() {
             Ok(blockchain_info) => {
+                let peers = self
+                    .rpc_client
+                    .get_network_info()
+                    .map(|info| info.connections as u64)
+                    .ok();
+                let mempool_tx = self
+                    .rpc_client
+                    .get_mempool_info()
+                    .map(|info| info.size as u64)
+                    .ok();
                 let _ = sender.send(Event::NodeUpdate(
                     index,
                     Arc::new(move |mut state| {
@@ -196,17 +274,31 @@ impl BitcoinCore {
                             .entry("RPC".to_string())
                             .or_insert(NodeStatus::Online) = NodeStatus::Online;
 
-                        let title = state
+                        let previous = state
                             .widget_state
                             .as_any()
                             .downcast_ref::<BitcoinCoreWidgetState>()
+                            .cloned();
+                        let title = previous
+                            .as_ref()
                             .map(|ws| ws.title.clone())
-                            .unwrap_or("Bitcoin Core".to_string());
+                            .filter(|title| !title.is_empty())
+                            .unwrap_or_else(|| "Bitcoin Core".to_string());
 
                         state.widget_state = Box::new(BitcoinCoreWidgetState {
                             title,
                             headers: blockchain_info.headers,
                             last_hash: blockchain_info.best_block_hash.to_string(),
+                            chain: blockchain_info.chain.to_string(),
+                            peers: peers
+                                .or_else(|| previous.as_ref().map(|s| s.peers))
+                                .unwrap_or(0),
+                            mempool_tx: mempool_tx
+                                .or_else(|| previous.as_ref().map(|s| s.mempool_tx))
+                                .unwrap_or(0),
+                            size_on_disk: blockchain_info.size_on_disk,
+                            verification_progress: blockchain_info.verification_progress,
+                            pruned: blockchain_info.pruned,
                         });
 
                         state
@@ -263,11 +355,9 @@ impl BitcoinCore {
                                             .unwrap();
                                         if widget_state.last_hash != hash {
                                             state.height += 1;
-                                            state.widget_state = Box::new(BitcoinCoreWidgetState {
-                                                title: widget_state.title.clone(),
-                                                headers: widget_state.headers,
-                                                last_hash: hash.clone(),
-                                            });
+                                            let mut next = widget_state.clone();
+                                            next.last_hash = hash.clone();
+                                            state.widget_state = Box::new(next);
                                         }
 
                                         state.last_hash_instant = Some(Instant::now());
@@ -395,9 +485,8 @@ impl NodeProvider for BitcoinCore {
                 state.host = host.clone();
                 state.message = "Initializing Bitcoin Core...".to_string();
                 state.widget_state = Box::new(BitcoinCoreWidgetState {
-                    title: format!("Bitcoin Core ({})", host),
-                    headers: 0,
-                    last_hash: "".to_string(),
+                    title: format!("Bitcoin Core ({host})"),
+                    ..BitcoinCoreWidgetState::default()
                 });
                 state
                     .services

--- a/src/node/providers/core_lightning.rs
+++ b/src/node/providers/core_lightning.rs
@@ -124,58 +124,56 @@ impl DynamicNodeStatefulWidget for CoreLightningWidget {
             .downcast_mut::<CoreLightningWidgetState>()
             .unwrap_or(&mut default);
 
-        let alias_text = match config.streamer_mode {
-            true => "****".to_string(),
-            false => state.alias.clone(),
+        let alias_text = if config.streamer_mode {
+            "****".to_string()
+        } else {
+            state.alias.clone()
         };
-        let mut lines = Vec::new();
-        lines.push(Line::from(vec![
-            Span::raw("Block Height: "),
-            Span::styled(node_state.height.to_string(), Style::new().fg(Color::White)),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Alias: "),
-            Span::styled(alias_text, Style::new().fg(Color::White)),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Active Channels: "),
-            Span::styled(
-                state.num_active_channels.to_string(),
-                Style::new().fg(Color::White),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Pending Channels: "),
-            Span::styled(
-                state.num_pending_channels.to_string(),
-                Style::new().fg(Color::White),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Inactive Channels: "),
-            Span::styled(
-                state.num_inactive_channels.to_string(),
-                Style::new().fg(Color::White),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Peers: "),
-            Span::styled(state.num_peers.to_string(), Style::new().fg(Color::White)),
-        ]));
+        let mut lines = vec![
+            Line::from(vec![
+                Span::raw("Height: "),
+                Span::styled(
+                    crate::format::commas(node_state.height),
+                    Style::new().fg(Color::White),
+                ),
+            ]),
+            Line::from(vec![
+                Span::raw("Alias: "),
+                Span::styled(alias_text, Style::new().fg(Color::White)),
+            ]),
+            Line::from(vec![
+                Span::raw("Channels: "),
+                Span::styled(
+                    format!(
+                        "{} up · {} pend · {} down",
+                        crate::format::commas(state.num_active_channels as u64),
+                        crate::format::commas(state.num_pending_channels as u64),
+                        crate::format::commas(state.num_inactive_channels as u64)
+                    ),
+                    Style::new().fg(Color::White),
+                ),
+            ]),
+            Line::from(vec![
+                Span::raw("Peers: "),
+                Span::styled(
+                    format!(
+                        "{} · {} htlc",
+                        crate::format::commas(state.num_peers as u64),
+                        crate::format::commas(state.num_pending_htlcs as u64)
+                    ),
+                    Style::new().fg(Color::White),
+                ),
+            ]),
+        ];
         if let Some(count) = state.num_watchtowers {
             lines.push(Line::from(vec![
-                Span::raw("Connected Towers: "),
-                Span::styled(count.to_string(), Style::new().fg(Color::White)),
+                Span::raw("Towers: "),
+                Span::styled(
+                    crate::format::commas(count as u64),
+                    Style::new().fg(Color::White),
+                ),
             ]));
         }
-        lines.push(Line::from(vec![
-            Span::raw("Pending HTLCs: "),
-            Span::styled(
-                state.num_pending_htlcs.to_string(),
-                Style::new().fg(Color::White),
-            ),
-        ]));
-        lines.push(Line::raw(""));
 
         if config.streamer_mode {
             let widget = BlockedParagraph::new(&state.title, node_state.status, lines);

--- a/src/node/providers/lnd.rs
+++ b/src/node/providers/lnd.rs
@@ -138,95 +138,86 @@ impl DynamicNodeStatefulWidget for LndWidget {
             .downcast_mut::<LndWidgetState>()
             .unwrap_or(&mut default);
 
-        let block_height = match node_state.status {
-            NodeStatus::Synchronizing => Line::from(vec![
-                Span::raw("Block Height: "),
-                Span::styled(node_state.height.to_string(), Style::new().fg(Color::White)),
-            ]),
-            _ => Line::from(vec![
-                Span::raw("Block Height: "),
-                Span::styled(node_state.height.to_string(), Style::new().fg(Color::White)),
-            ]),
+        let alias_text = if config.streamer_mode {
+            "****".to_string()
+        } else {
+            state.alias.clone()
         };
-
-        let alias_text = match config.streamer_mode {
-            true => "****".to_string(),
-            false => state.alias.clone(),
-        };
-        let mut lines = Vec::new();
-        lines.push(block_height);
-        lines.push(Line::from(vec![
-            Span::raw("Alias: "),
-            Span::styled(alias_text, Style::new().fg(Color::White)),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Active Channels: "),
-            Span::styled(
-                state.num_active_channels.to_string(),
-                Style::new().fg(Color::White),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Pending Channels: "),
-            Span::styled(
-                state.num_pending_channels.to_string(),
-                Style::new().fg(Color::White),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Inactive Channels: "),
-            Span::styled(
-                state.num_inactive_channels.to_string(),
-                Style::new().fg(Color::White),
-            ),
-        ]));
-        lines.push(Line::from(vec![
-            Span::raw("Peers: "),
-            Span::styled(state.num_peers.to_string(), Style::new().fg(Color::White)),
-        ]));
+        let mut towers = String::new();
         if let Some(count) = state.num_watchtowers {
-            lines.push(Line::from(vec![
-                Span::raw("Connected Towers: "),
-                Span::styled(count.to_string(), Style::new().fg(Color::White)),
-            ]));
+            towers.push_str(&format!("{} client", count));
         }
-        lines.push(Line::from(vec![
-            Span::raw("Pending HTLCs: "),
-            Span::styled(
-                state.num_pending_htlcs.to_string(),
-                Style::new().fg(Color::White),
-            ),
-        ]));
         if let Some(is_online) = state.watchtower_server_online {
-            let status = if is_online { "Online" } else { "Offline" };
+            if !towers.is_empty() {
+                towers.push_str(" · ");
+            }
+            towers.push_str(if is_online {
+                "server up"
+            } else {
+                "server down"
+            });
+        }
+        let mut lines = vec![
+            Line::from(vec![
+                Span::raw("Height: "),
+                Span::styled(
+                    crate::format::commas(node_state.height),
+                    Style::new().fg(Color::White),
+                ),
+            ]),
+            Line::from(vec![
+                Span::raw("Alias: "),
+                Span::styled(alias_text, Style::new().fg(Color::White)),
+            ]),
+            Line::from(vec![
+                Span::raw("Channels: "),
+                Span::styled(
+                    format!(
+                        "{} up · {} pend · {} down",
+                        crate::format::commas(state.num_active_channels),
+                        crate::format::commas(state.num_pending_channels),
+                        crate::format::commas(state.num_inactive_channels)
+                    ),
+                    Style::new().fg(Color::White),
+                ),
+            ]),
+            Line::from(vec![
+                Span::raw("Peers: "),
+                Span::styled(
+                    format!(
+                        "{} · {} htlc",
+                        crate::format::commas(state.num_peers as u64),
+                        crate::format::commas(state.num_pending_htlcs)
+                    ),
+                    Style::new().fg(Color::White),
+                ),
+            ]),
+        ];
+        if !towers.is_empty() {
             lines.push(Line::from(vec![
-                Span::raw("Tower Server: "),
-                Span::styled(status, Style::new().fg(Color::White)),
+                Span::raw("Towers: "),
+                Span::styled(towers, Style::new().fg(Color::White)),
             ]));
         }
         lines.push(Line::from(vec![
-            Span::raw("Synced to Bitcoin: "),
+            Span::raw("Sync: "),
             Span::styled(
-                if state.synced_to_chain {
-                    "True"
-                } else {
-                    "False"
-                },
+                format!(
+                    "chain {} · graph {}",
+                    if state.synced_to_chain {
+                        "up"
+                    } else {
+                        "behind"
+                    },
+                    if state.synced_to_graph {
+                        "up"
+                    } else {
+                        "behind"
+                    }
+                ),
                 Style::new().fg(Color::White),
             ),
         ]));
-        lines.push(Line::from(vec![
-            Span::raw("Synced to Lightning: "),
-            Span::styled(
-                if state.synced_to_graph {
-                    "True"
-                } else {
-                    "False"
-                },
-                Style::new().fg(Color::White),
-            ),
-        ]));
-        lines.push(Line::raw(""));
 
         if config.streamer_mode {
             let widget = BlockedParagraph::new(&state.title, node_state.status, lines);

--- a/src/price/mod.rs
+++ b/src/price/mod.rs
@@ -51,6 +51,7 @@ pub struct PriceState {
     pub currency: PriceCurrency,
     pub last_price_in_currency: Option<f64>,
     pub last_error: Option<String>,
+    pub last_ok_at: Option<tokio::time::Instant>,
 }
 
 impl Default for PriceState {
@@ -59,6 +60,7 @@ impl Default for PriceState {
             currency: PriceCurrency::USD,
             last_price_in_currency: None,
             last_error: None,
+            last_ok_at: None,
         }
     }
 }
@@ -119,17 +121,20 @@ async fn price_checker<T: PriceProvider>(
                             currency,
                             last_price_in_currency: Some(price),
                             last_error: None,
+                            last_ok_at: Some(tokio::time::Instant::now()),
                         },
                         Err(error) => PriceState {
                             currency,
                             last_price_in_currency: None,
                             last_error: Some(format!("bad price: {error}")),
+                            last_ok_at: None,
                         },
                     },
                     Err(error) => PriceState {
                         currency,
                         last_price_in_currency: None,
                         last_error: Some(short_error(&*error)),
+                        last_ok_at: None,
                     },
                 };
                 let _ = sender.send(Event::PriceUpdate(update));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -189,15 +189,16 @@ fn render_node_summary(app: &App, frame: &mut Frame, area: Rect) {
                 if state.height == 0 {
                     "--".to_string()
                 } else {
-                    state.height.to_string()
+                    crate::format::commas(state.height)
                 },
                 Style::default()
                     .fg(Color::White)
                     .add_modifier(Modifier::BOLD),
             ),
         ]),
-        Line::from(service_spans),
     ];
+    lines.extend(node_glance_lines(state, app.config.streamer_mode));
+    lines.push(Line::from(service_spans));
     if !state.message.is_empty() {
         lines.push(Line::from(vec![
             Span::styled("INFO      ", Style::default().fg(Color::DarkGray)),
@@ -214,17 +215,37 @@ fn render_node_status(app: &App, frame: &mut Frame, area: Rect) {
 }
 
 fn render_price_view(config: &AppConfig, app: &mut App, frame: &mut Frame, area: Rect) {
+    let spark_height = if area.height >= 12 { 2 } else { 0 };
+    let footer_height = if area.height >= 10 { 2 } else { 1 };
     let layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(0), Constraint::Length(1)])
+        .constraints([
+            Constraint::Min(0),
+            Constraint::Length(spark_height),
+            Constraint::Length(footer_height),
+        ])
         .split(area);
     render_price_widget(app, frame, layout[0], "Bitcoin Price", PixelSize::Full);
 
-    let (status_text, status_style) = get_price_variation_text(config, &app.state);
+    if spark_height > 0 {
+        let values: Vec<f64> = app
+            .state
+            .price_history
+            .iter()
+            .map(|(_, price)| *price)
+            .collect();
+        let spark = crate::format::sparkline(&values, layout[1].width as usize);
+        Paragraph::new(spark)
+            .style(Style::default().fg(BITCOIN_ORANGE))
+            .alignment(Alignment::Center)
+            .render(layout[1], frame.buffer_mut());
+    }
+
+    let (status_text, status_style) = get_price_ticker_footer(config, &app.state);
     Paragraph::new(status_text)
         .style(status_style)
         .alignment(Alignment::Center)
-        .render(layout[1], frame.buffer_mut());
+        .render(layout[2], frame.buffer_mut());
 }
 
 fn render_price_widget(
@@ -532,6 +553,126 @@ fn get_price_style(config: &AppConfig, state: &crate::app::AppState) -> Style {
     } else {
         Style::default().fg(Color::White)
     }
+}
+
+fn node_glance_lines(state: &crate::node::NodeState, streamer_mode: bool) -> Vec<Line<'_>> {
+    use crate::node::providers::bitcoin_core::BitcoinCoreWidgetState;
+    use crate::node::providers::core_lightning::CoreLightningWidgetState;
+    use crate::node::providers::lnd::LndWidgetState;
+
+    if let Some(core) = state
+        .widget_state
+        .as_any()
+        .downcast_ref::<BitcoinCoreWidgetState>()
+    {
+        let mut lines = vec![Line::from(vec![
+            Span::styled("NETWORK   ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!(
+                    "{} · {} peers",
+                    crate::format::chain_label(&core.chain),
+                    crate::format::commas(core.peers)
+                ),
+                Style::default().fg(Color::White),
+            ),
+        ])];
+        if core.mempool_tx > 0 {
+            lines.push(Line::from(vec![
+                Span::styled("MEMPOOL   ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    format!("{} tx", crate::format::commas(core.mempool_tx)),
+                    Style::default().fg(Color::White),
+                ),
+            ]));
+        }
+        return lines;
+    }
+
+    let channels = state
+        .widget_state
+        .as_any()
+        .downcast_ref::<LndWidgetState>()
+        .map(|ln| {
+            (
+                ln.num_active_channels,
+                ln.num_pending_channels,
+                ln.num_inactive_channels,
+                ln.local_balance,
+                ln.capacity,
+            )
+        })
+        .or_else(|| {
+            state
+                .widget_state
+                .as_any()
+                .downcast_ref::<CoreLightningWidgetState>()
+                .map(|ln| {
+                    (
+                        ln.num_active_channels as u64,
+                        ln.num_pending_channels as u64,
+                        ln.num_inactive_channels as u64,
+                        ln.local_balance,
+                        ln.total_capacity,
+                    )
+                })
+        });
+
+    let Some((active, pending, inactive, local, capacity)) = channels else {
+        return Vec::new();
+    };
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled("CHANNELS  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            format!(
+                "{} up · {} pend · {} down",
+                crate::format::commas(active),
+                crate::format::commas(pending),
+                crate::format::commas(inactive)
+            ),
+            Style::default().fg(Color::White),
+        ),
+    ])];
+    if !streamer_mode && capacity > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("BALANCE   ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                format!(
+                    "{} / {} sats",
+                    crate::format::commas(local),
+                    crate::format::commas(capacity)
+                ),
+                Style::default().fg(Color::White),
+            ),
+        ]));
+    }
+    lines
+}
+
+fn get_price_ticker_footer(config: &AppConfig, state: &crate::app::AppState) -> (String, Style) {
+    let (change, style) = get_price_variation_text(config, state);
+    if state.price.last_error.is_some() {
+        return (change, style);
+    }
+
+    let values: Vec<f64> = state
+        .price_history
+        .iter()
+        .map(|(_, price)| *price)
+        .collect();
+    if values.is_empty() {
+        return (change, style);
+    }
+    let high = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let low = values.iter().copied().fold(f64::INFINITY, f64::min);
+    (
+        format!(
+            "{change}  ·  H {}  L {}",
+            crate::format::commas(high.trunc() as u64),
+            crate::format::commas(low.trunc() as u64)
+        ),
+        style,
+    )
 }
 
 fn get_price_variation_text(config: &AppConfig, state: &crate::app::AppState) -> (String, Style) {

--- a/src/ui/price.rs
+++ b/src/ui/price.rs
@@ -44,7 +44,7 @@ impl StatefulWidget for PriceWidget {
         let price_with_currency_lines: Vec<ratatui::text::Line<'static>> =
             match state.price.last_price_in_currency {
                 Some(v) => vec![
-                    v.trunc().to_string().into(),
+                    crate::format::commas(v.trunc() as u64).into(),
                     state.price.currency.to_string().into(),
                 ],
                 None => vec!["...".into()],


### PR DESCRIPTION
Fixes GURI-133

## Why

The Core pane was height plus a full hash. Lightning was a True/False list. Price-only was a number and a one-line percent. The Pi screens have room for facts you can read at a glance.

## What Changed

- Bitcoin Core: height, short tip, network/peers, mempool, disk, sync %.
- LND / CLN: compact channel, peer, tower, and sync rows. Balance gauge unchanged. Streamer mode still redacts alias and balances.
- Price-only: thousands separators, sparkline, session high/low next to the variation line.

## Verification

`cargo test` — 23 passed.
