### PR TITLE
Drop commas from the big price

### DIFF
--- a/src/ui/price.rs
+++ b/src/ui/price.rs
@@ -44,7 +44,7 @@ impl StatefulWidget for PriceWidget {
         let price_with_currency_lines: Vec<ratatui::text::Line<'static>> =
             match state.price.last_price_in_currency {
                 Some(v) => vec![
-                    crate::format::commas(v.trunc() as u64).into(),
+                    v.trunc().to_string().into(),
                     state.price.currency.to_string().into(),
                 ],
                 None => vec!["...".into()],


### PR DESCRIPTION
Fixes GURI-133 follow-up: the full-size price stays unformatted.