### PR TITLE
Drive the dock from the ADS7846 digitizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 
 - Price and fee panels keep the last good value when a refresh fails and show `STALE` or `ERR` instead of going blank.
 - Node views show glanceable facts: Core peers/mempool/disk/sync, compact Lightning channel rows. Price-only adds a sparkline and session high/low.
+- Touch on the Pi framebuffer consoles now drives the dock (ADS7846 / tft35a).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +293,7 @@ dependencies = [
  "bitcoincore-zmq",
  "config",
  "crossterm 0.27.0",
+ "evdev",
  "futures",
  "hex",
  "home",
@@ -355,6 +368,12 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "compact_str"
@@ -728,6 +747,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "evdev"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
+dependencies = [
+ "bitvec",
+ "cfg-if 1.0.1",
+ "libc",
+ "nix",
+ "tokio",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +822,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1579,6 +1617,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.1",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +1860,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2434,6 +2490,12 @@ dependencies = [
  "toml",
  "version-compare",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -3295,6 +3357,15 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,4 @@ anyhow = "1.0.86"
 zmq = "0.10.0"
 bitcoincore-zmq = { version = "1.5.1", features = ["async"] }
 tui-widgets = { version = "0.4.1", features = ["tui-big-text", "tui-popup"] }
+evdev = { version = "0.13.2", features = ["tokio"] }

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ See the [Example config.toml](share/config/example.toml) file
 
 ## Touch controls
 
-On displays with mouse reporting enabled, the bottom dock provides large touch targets:
+On a Linux framebuffer console, btcmon reads the digitizer (`ADS7846` / tft35a)
+directly. Xterm mouse reporting still works under VNC. The bottom dock provides
+large touch targets:
 
 - `<` / `>` selects and pins the previous or next node so it stays on screen.
 - Tapping the node name toggles rotation between `AUTO` and `PINNED` (and resumes automatic rotation after a manual selection).

--- a/share/config/example.toml
+++ b/share/config/example.toml
@@ -22,3 +22,9 @@ variation_threshold = 0.0
 
 [fees]
 enabled = true
+
+[touch]
+enabled = true
+swap_xy = true
+invert_x = true
+invert_y = false

--- a/src/app.rs
+++ b/src/app.rs
@@ -503,6 +503,7 @@ mod tests {
             bitcoin_core: BitcoinCoreSettings::default(),
             core_lightning: CoreLightningSettings::default(),
             lnd: LndSettings::default(),
+            touch: crate::config::TouchSettings::default(),
             nodes: (0..node_count)
                 .map(|index| NodeConfig {
                     name: Some(format!("Node {}", index + 1)),

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,28 @@ pub struct FeesSettings {
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
+pub struct TouchSettings {
+    pub enabled: bool,
+    pub device: String,
+    pub swap_xy: bool,
+    pub invert_x: bool,
+    pub invert_y: bool,
+}
+
+impl Default for TouchSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            device: String::new(),
+            swap_xy: true,
+            invert_x: true,
+            invert_y: false,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
 pub struct NodeConfig {
     #[serde(default)]
     pub name: Option<String>,
@@ -67,6 +89,8 @@ pub struct AppConfig {
     pub lnd: LndSettings,
     #[serde(default)]
     pub nodes: Vec<NodeConfig>,
+    #[serde(default)]
+    pub touch: TouchSettings,
 }
 
 fn match_string_to_bool(value: &str) -> bool {
@@ -106,7 +130,12 @@ impl AppConfig {
             .set_default("price.variation", "minute")?
             .set_default("price.variation_threshold", 0.0)?
             // fees
-            .set_default("fees.enabled", true)?;
+            .set_default("fees.enabled", true)?
+            .set_default("touch.enabled", true)?
+            .set_default("touch.device", "")?
+            .set_default("touch.swap_xy", true)?
+            .set_default("touch.invert_x", true)?
+            .set_default("touch.invert_y", false)?;
 
         let mut default_config_file: String = String::from("/etc/btcmon/btcmon.toml");
 
@@ -139,7 +168,8 @@ impl AppConfig {
                 .and_then(|v| Some(v.first().unwrap().as_str()))
             {
                 match key.as_str() {
-                    "price.enabled" | "fees.enabled" | "streamer_mode" => {
+                    "price.enabled" | "fees.enabled" | "streamer_mode" | "touch.enabled"
+                    | "touch.swap_xy" | "touch.invert_x" | "touch.invert_y" => {
                         s = s.set_override(key, match_string_to_bool(value))?;
                     }
                     _ => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,5 @@ pub mod fees;
 pub mod widget;
 
 pub mod format;
+
+pub mod touch;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use btcmon::node::providers::core_lightning::{
 };
 use btcmon::node::providers::lnd::{LndNode, LndWidget, LndWidgetState};
 use btcmon::node::NodeProvider;
+use btcmon::touch::spawn_touch_listener;
 use btcmon::tui::Tui;
 use btcmon::widget::{DynamicNodeStatefulWidget, DynamicState};
 use ratatui::backend::CrosstermBackend;
@@ -129,6 +130,7 @@ async fn main() -> AppResult<()> {
 
     let mut tui = Tui::new(terminal, events);
     tui.init()?;
+    spawn_touch_listener(app.thread.clone(), config.touch.clone());
     tui.draw(&config, &mut app)?;
 
     // Initialize all nodes

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -1,0 +1,200 @@
+use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use evdev::{AbsoluteAxisCode, Device, EventType, InputEvent, KeyCode};
+use std::path::PathBuf;
+use tokio::sync::mpsc;
+
+use crate::app::AppThread;
+use crate::config::TouchSettings;
+use crate::event::Event;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TouchMap {
+    pub min_x: i32,
+    pub max_x: i32,
+    pub min_y: i32,
+    pub max_y: i32,
+    pub swap_xy: bool,
+    pub invert_x: bool,
+    pub invert_y: bool,
+}
+
+impl TouchMap {
+    pub fn cell(self, raw_x: i32, raw_y: i32, cols: u16, rows: u16) -> (u16, u16) {
+        let mut nx = normalize(raw_x, self.min_x, self.max_x);
+        let mut ny = normalize(raw_y, self.min_y, self.max_y);
+        if self.swap_xy {
+            std::mem::swap(&mut nx, &mut ny);
+        }
+        if self.invert_x {
+            nx = 1.0 - nx;
+        }
+        if self.invert_y {
+            ny = 1.0 - ny;
+        }
+        let col =
+            ((nx * f64::from(cols.saturating_sub(1))).round() as u16).min(cols.saturating_sub(1));
+        let row =
+            ((ny * f64::from(rows.saturating_sub(1))).round() as u16).min(rows.saturating_sub(1));
+        (col, row)
+    }
+}
+
+fn normalize(value: i32, min: i32, max: i32) -> f64 {
+    if max <= min {
+        return 0.5;
+    }
+    ((value.clamp(min, max) - min) as f64) / ((max - min) as f64)
+}
+
+pub fn spawn_touch_listener(thread: AppThread, settings: TouchSettings) {
+    if !settings.enabled {
+        return;
+    }
+    thread.tracker.spawn(async move {
+        tokio::select! {
+            () = thread.token.cancelled() => {}
+            () = run_touch(thread.sender, settings) => {}
+        }
+    });
+}
+
+async fn run_touch(sender: mpsc::UnboundedSender<Event>, settings: TouchSettings) {
+    let Some((path, device, map)) = open_touch_device(&settings) else {
+        return;
+    };
+    let _ = path;
+    let Ok(mut stream) = device.into_event_stream() else {
+        return;
+    };
+
+    let mut raw_x = 0;
+    let mut raw_y = 0;
+    let mut pressed = false;
+    let mut was_pressed = false;
+
+    loop {
+        let event = match stream.next_event().await {
+            Ok(event) => event,
+            Err(_) => break,
+        };
+        apply_event(event, &mut raw_x, &mut raw_y, &mut pressed);
+        if event.event_type() != EventType::SYNCHRONIZATION {
+            continue;
+        }
+        if pressed && !was_pressed {
+            let (cols, rows) = crossterm::terminal::size().unwrap_or((80, 24));
+            let (column, row) = map.cell(raw_x, raw_y, cols, rows);
+            let _ = sender.send(Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column,
+                row,
+                modifiers: KeyModifiers::NONE,
+            }));
+        }
+        was_pressed = pressed;
+    }
+}
+
+fn apply_event(event: InputEvent, raw_x: &mut i32, raw_y: &mut i32, pressed: &mut bool) {
+    match event.event_type() {
+        EventType::ABSOLUTE => {
+            if event.code() == AbsoluteAxisCode::ABS_X.0 {
+                *raw_x = event.value();
+            } else if event.code() == AbsoluteAxisCode::ABS_Y.0 {
+                *raw_y = event.value();
+            } else if event.code() == AbsoluteAxisCode::ABS_PRESSURE.0 {
+                *pressed = event.value() > 0;
+            }
+        }
+        EventType::KEY if event.code() == KeyCode::BTN_TOUCH.0 => {
+            *pressed = event.value() > 0;
+        }
+        _ => {}
+    }
+}
+
+fn open_touch_device(settings: &TouchSettings) -> Option<(PathBuf, Device, TouchMap)> {
+    if !settings.device.trim().is_empty() {
+        return load_device(PathBuf::from(settings.device.trim()), settings);
+    }
+    evdev::enumerate().find_map(|(path, device)| {
+        let name = device.name().unwrap_or("");
+        let looks_like_touch = name.contains("ADS7846")
+            || name.contains("Touchscreen")
+            || name.contains("Touch")
+            || device.supported_absolute_axes().is_some_and(|axes| {
+                axes.contains(AbsoluteAxisCode::ABS_X) && axes.contains(AbsoluteAxisCode::ABS_Y)
+            });
+        if looks_like_touch {
+            load_device_from(path, device, settings)
+        } else {
+            None
+        }
+    })
+}
+
+fn load_device(path: PathBuf, settings: &TouchSettings) -> Option<(PathBuf, Device, TouchMap)> {
+    let device = Device::open(&path).ok()?;
+    load_device_from(path, device, settings)
+}
+
+fn load_device_from(
+    path: PathBuf,
+    device: Device,
+    settings: &TouchSettings,
+) -> Option<(PathBuf, Device, TouchMap)> {
+    let mut min_x = 0;
+    let mut max_x = 4095;
+    let mut min_y = 0;
+    let mut max_y = 4095;
+    if let Ok(info) = device.get_absinfo() {
+        for (axis, abs) in info {
+            if axis == AbsoluteAxisCode::ABS_X {
+                min_x = abs.minimum();
+                max_x = abs.maximum();
+            } else if axis == AbsoluteAxisCode::ABS_Y {
+                min_y = abs.minimum();
+                max_y = abs.maximum();
+            }
+        }
+    }
+    Some((
+        path,
+        device,
+        TouchMap {
+            min_x,
+            max_x,
+            min_y,
+            max_y,
+            swap_xy: settings.swap_xy,
+            invert_x: settings.invert_x,
+            invert_y: settings.invert_y,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TouchMap;
+
+    fn map() -> TouchMap {
+        TouchMap {
+            min_x: 0,
+            max_x: 1000,
+            min_y: 0,
+            max_y: 1000,
+            swap_xy: true,
+            invert_x: true,
+            invert_y: false,
+        }
+    }
+
+    #[test]
+    fn tft35a_rotate_270_maps_corners() {
+        let touch = map();
+        assert_eq!(touch.cell(0, 0, 80, 24), (79, 0));
+        assert_eq!(touch.cell(1000, 1000, 80, 24), (0, 23));
+        assert_eq!(touch.cell(0, 1000, 80, 24), (0, 0));
+        assert_eq!(touch.cell(1000, 0, 80, 24), (79, 23));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -797,6 +797,7 @@ mod tests {
             bitcoin_core: BitcoinCoreSettings::default(),
             core_lightning: CoreLightningSettings::default(),
             lnd: LndSettings::default(),
+            touch: crate::config::TouchSettings::default(),
             nodes: (0..node_count)
                 .map(|index| NodeConfig {
                     name: Some(format!("Pi {}", index + 1)),


### PR DESCRIPTION
Fixes GURI-136

## Why

The money monitor has no keyboard. Touch never reached the dock because btcmon runs on raw tty1 and Crossterm only sees xterm mouse codes. Both Pis have the same ADS7846 panel; swapping screens would not help.

## What Changed

- Read the digitizer via evdev and emit the existing dock mouse-down events.
- Defaults match `tft35a:rotate=270` (`swap_xy`, `invert_x`). Flip in `[touch]` if a tap lands on the wrong side.

## Verification

`cargo test` — 24 passed, including axis mapping corners.
