### PR TITLE
Draw a real price-only line chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Improvements
 
+- Price-only draws a multi-row line chart with a moving `*` for the latest tick, instead of a one-line bar strip and H/L footer.
 - Price and fee panels keep the last good value when a refresh fails and show `STALE` or `ERR` instead of going blank.
 - Node views show glanceable facts: Core peers/mempool/disk/sync, compact Lightning channel rows. Price-only adds a sparkline and session high/low.
 - Touch on the Pi framebuffer consoles now drives the dock (ADS7846 / tft35a).

--- a/src/format.rs
+++ b/src/format.rs
@@ -40,18 +40,14 @@ pub fn sparkline(values: &[f64], width: usize) -> String {
         return String::new();
     }
 
-    let min = values.iter().copied().fold(f64::INFINITY, f64::min);
-    let max = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let samples = sample_series(values, width);
+    let min = samples.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = samples.iter().copied().fold(f64::NEG_INFINITY, f64::max);
     let span = max - min;
 
-    (0..width)
-        .map(|column| {
-            let index = if width == 1 {
-                values.len() - 1
-            } else {
-                column * (values.len() - 1) / (width - 1)
-            };
-            let value = values[index];
+    samples
+        .into_iter()
+        .map(|value| {
             if !value.is_finite() {
                 return ' ';
             }
@@ -61,6 +57,86 @@ pub fn sparkline(values: &[f64], width: usize) -> String {
                 (((value - min) / span) * 7.0).round() as usize
             };
             BARS[rank.min(7)]
+        })
+        .collect()
+}
+
+pub fn line_chart(values: &[f64], width: usize, height: usize) -> Vec<String> {
+    if height == 0 {
+        return Vec::new();
+    }
+    if width == 0 || values.is_empty() {
+        return vec![" ".repeat(width); height];
+    }
+
+    let samples = sample_series(values, width);
+    let min = samples.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = samples.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let span = max - min;
+    let levels = height * 2;
+    let ys: Vec<usize> = samples
+        .iter()
+        .map(|value| {
+            if !value.is_finite() || span <= f64::EPSILON {
+                return (levels - 1) / 2;
+            }
+            let rank = ((value - min) / span) * (levels - 1) as f64;
+            rank.round().clamp(0.0, (levels - 1) as f64) as usize
+        })
+        .collect();
+
+    let mut pixels = vec![vec![false; width]; levels];
+    for x in 0..width {
+        let y = ys[x];
+        if x > 0 {
+            let prev = ys[x - 1];
+            let lo = prev.min(y);
+            let hi = prev.max(y);
+            for yy in lo..=hi {
+                pixels[levels - 1 - yy][x] = true;
+            }
+        } else {
+            pixels[levels - 1 - y][x] = true;
+        }
+    }
+
+    let mut rows = Vec::with_capacity(height);
+    for row in 0..height {
+        let mut line = String::with_capacity(width);
+        for x in 0..width {
+            let top = pixels[row * 2][x];
+            let bottom = pixels[row * 2 + 1][x];
+            line.push(match (top, bottom) {
+                (true, true) => '█',
+                (true, false) => '▀',
+                (false, true) => '▄',
+                (false, false) => ' ',
+            });
+        }
+        rows.push(line);
+    }
+
+    let last_x = width - 1;
+    let last_row = (levels - 1 - ys[last_x]) / 2;
+    if let Some(line) = rows.get_mut(last_row) {
+        let mut chars: Vec<char> = line.chars().collect();
+        if last_x < chars.len() {
+            chars[last_x] = '*';
+            *line = chars.into_iter().collect();
+        }
+    }
+    rows
+}
+
+fn sample_series(values: &[f64], width: usize) -> Vec<f64> {
+    (0..width)
+        .map(|column| {
+            let index = if width == 1 {
+                values.len() - 1
+            } else {
+                column * (values.len() - 1) / (width - 1)
+            };
+            values[index]
         })
         .collect()
 }
@@ -78,7 +154,7 @@ pub fn chain_label(chain: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use super::{bytes_compact, commas, short_hash, sparkline};
+    use super::{bytes_compact, commas, line_chart, short_hash, sparkline};
 
     #[test]
     fn commas_groups_thousands() {
@@ -100,6 +176,29 @@ mod tests {
         let line = sparkline(&[1.0, 2.0, 3.0, 2.5], 8);
         assert_eq!(line.chars().count(), 8);
         assert!(line.chars().all(|ch| "▁▂▃▄▅▆▇█".contains(ch)));
+    }
+
+    #[test]
+    fn line_chart_uses_half_blocks_and_marks_the_latest_point() {
+        let rows = line_chart(&[1.0, 2.0, 3.0, 4.0], 8, 4);
+        assert_eq!(rows.len(), 4);
+        assert!(rows.iter().all(|row| row.chars().count() == 8));
+        assert!(rows.iter().all(|row| {
+            row.chars()
+                .all(|ch| matches!(ch, ' ' | '▀' | '▄' | '█' | '*'))
+        }));
+        assert!(rows.iter().any(|row| row.contains('*')));
+        let first_ink = rows
+            .iter()
+            .rev()
+            .find_map(|row| row.chars().position(|ch| ch != ' '));
+        let last_ink = rows.iter().find_map(|row| {
+            row.chars()
+                .rev()
+                .position(|ch| ch != ' ')
+                .map(|from_end| row.chars().count() - 1 - from_end)
+        });
+        assert!(first_ink.unwrap() < last_ink.unwrap());
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -216,37 +216,49 @@ fn render_node_status(app: &App, frame: &mut Frame, area: Rect) {
 }
 
 fn render_price_view(config: &AppConfig, app: &mut App, frame: &mut Frame, area: Rect) {
-    let spark_height = if area.height >= 12 { 2 } else { 0 };
-    let footer_height = if area.height >= 10 { 2 } else { 1 };
+    let footer_height = if app.state.price.last_error.is_some() {
+        1
+    } else {
+        0
+    };
+    let chart_height = match area.height {
+        12.. => 5,
+        10 | 11 => 4,
+        8 | 9 => 3,
+        _ => 0,
+    };
+    let chart_height = (chart_height as u16).saturating_sub(footer_height);
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(0),
-            Constraint::Length(spark_height),
+            Constraint::Length(chart_height),
             Constraint::Length(footer_height),
         ])
         .split(area);
     render_price_widget(app, frame, layout[0], "Bitcoin Price", PixelSize::Full);
 
-    if spark_height > 0 {
+    if chart_height > 0 {
         let values: Vec<f64> = app
             .state
             .price_history
             .iter()
             .map(|(_, price)| *price)
             .collect();
-        let spark = crate::format::sparkline(&values, layout[1].width as usize);
-        Paragraph::new(spark)
+        let chart =
+            crate::format::line_chart(&values, layout[1].width as usize, chart_height as usize);
+        Paragraph::new(chart.join("\n"))
             .style(Style::default().fg(BITCOIN_ORANGE))
-            .alignment(Alignment::Center)
             .render(layout[1], frame.buffer_mut());
     }
 
-    let (status_text, status_style) = get_price_ticker_footer(config, &app.state);
-    Paragraph::new(status_text)
-        .style(status_style)
-        .alignment(Alignment::Center)
-        .render(layout[2], frame.buffer_mut());
+    if footer_height > 0 {
+        let (status_text, status_style) = get_price_variation_text(config, &app.state);
+        Paragraph::new(status_text)
+            .style(status_style)
+            .alignment(Alignment::Center)
+            .render(layout[2], frame.buffer_mut());
+    }
 }
 
 fn render_price_widget(
@@ -668,32 +680,6 @@ fn node_glance_lines(state: &crate::node::NodeState, streamer_mode: bool) -> Vec
         ]));
     }
     lines
-}
-
-fn get_price_ticker_footer(config: &AppConfig, state: &crate::app::AppState) -> (String, Style) {
-    let (change, style) = get_price_variation_text(config, state);
-    if state.price.last_error.is_some() {
-        return (change, style);
-    }
-
-    let values: Vec<f64> = state
-        .price_history
-        .iter()
-        .map(|(_, price)| *price)
-        .collect();
-    if values.is_empty() {
-        return (change, style);
-    }
-    let high = values.iter().copied().fold(f64::NEG_INFINITY, f64::max);
-    let low = values.iter().copied().fold(f64::INFINITY, f64::min);
-    (
-        format!(
-            "{change}  ·  H {}  L {}",
-            crate::format::commas(high.trunc() as u64),
-            crate::format::commas(low.trunc() as u64)
-        ),
-        style,
-    )
 }
 
 fn get_price_variation_text(config: &AppConfig, state: &crate::app::AppState) -> (String, Style) {


### PR DESCRIPTION
GURI-212

The one-row ▁▂▃ sparkline looks like a thick/thin line on the Pi console font. Price-only now uses a 3–5 row line chart made of ▀▄█ (glyphs that font actually has) and a `*` for the latest tick. The H/L footer is gone; STALE/ERR still shows when a refresh fails.