### PR TITLE
Timeout price and fee HTTP fetches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Price and fee fetches time out after 10–15 s instead of hanging forever on a dead connection, which left the price frozen without a STALE/ERR flag.
 - Core Lightning channel row counts connected `CHANNELD_NORMAL` peers as up, and disconnected or closing ones as down.
 
 ### Improvements

--- a/src/fees/mod.rs
+++ b/src/fees/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -93,13 +94,21 @@ async fn fees_checker<T: FeeServiceProvider>(
         }
         tokio::select! {
             () = token.cancelled() => {}
-            res = provider.fetch_current_fees() => {
+            res = tokio::time::timeout(Duration::from_secs(15), provider.fetch_current_fees()) => {
                 let update = match res {
-                    Ok(result) => FeesState {
+                    Err(_) => FeesState {
+                        result: FeeResult {
+                            low: None,
+                            medium: None,
+                            high: None,
+                        },
+                        last_error: Some("timed out".to_string()),
+                    },
+                    Ok(Ok(result)) => FeesState {
                         result,
                         last_error: None,
                     },
-                    Err(error) => FeesState {
+                    Ok(Err(error)) => FeesState {
                         result: FeeResult {
                             low: None,
                             medium: None,
@@ -109,7 +118,6 @@ async fn fees_checker<T: FeeServiceProvider>(
                     },
                 };
                 let _ = sender.send(Event::FeeUpdate(update));
-
             }
         }
 

--- a/src/fees/providers/mod.rs
+++ b/src/fees/providers/mod.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use serde::Deserialize;
+use std::time::Duration;
 
 use super::{FeeResult, FeeServiceProvider};
 pub struct FeesBlockchainInfo;
@@ -18,7 +19,9 @@ impl FeeServiceProvider for FeesBlockchainInfo {
     }
 
     async fn fetch_current_fees(&mut self) -> Result<FeeResult, Box<dyn std::error::Error>> {
-        let client = reqwest::Client::builder().build()?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()?;
         let response = client
             .get("https://api.blockchain.info/mempool/fees")
             .send()

--- a/src/price/mod.rs
+++ b/src/price/mod.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::fmt;
 use std::str::FromStr;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -114,9 +115,15 @@ async fn price_checker<T: PriceProvider>(
         }
         tokio::select! {
             () = token.cancelled() => {}
-            res = provider.fetch_current_price(&currency) => {
+            res = tokio::time::timeout(Duration::from_secs(15), provider.fetch_current_price(&currency)) => {
                 let update = match res {
-                    Ok(res) => match res.price_in_currency.parse::<f64>() {
+                    Err(_) => PriceState {
+                        currency,
+                        last_price_in_currency: None,
+                        last_error: Some("timed out".to_string()),
+                        last_ok_at: None,
+                    },
+                    Ok(Ok(res)) => match res.price_in_currency.parse::<f64>() {
                         Ok(price) => PriceState {
                             currency,
                             last_price_in_currency: Some(price),
@@ -130,7 +137,7 @@ async fn price_checker<T: PriceProvider>(
                             last_ok_at: None,
                         },
                     },
-                    Err(error) => PriceState {
+                    Ok(Err(error)) => PriceState {
                         currency,
                         last_price_in_currency: None,
                         last_error: Some(short_error(&*error)),

--- a/src/price/providers/coinbase.rs
+++ b/src/price/providers/coinbase.rs
@@ -1,6 +1,8 @@
 use crate::price::{PriceCurrency, PriceProvider, PriceResult};
 use async_trait::async_trait;
 use serde::Deserialize;
+use std::time::Duration;
+
 pub struct PriceCoinbase;
 
 #[derive(Debug, Deserialize)]
@@ -18,7 +20,9 @@ impl PriceProvider for PriceCoinbase {
         &mut self,
         currency: &PriceCurrency,
     ) -> Result<PriceResult, Box<dyn std::error::Error>> {
-        let client = reqwest::Client::builder().build()?;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()?;
         let response = client
             .get(format!(
                 "https://api.coinbase.com/api/v3/brokerage/market/products/BTC-{currency}"


### PR DESCRIPTION
GURI-219

The price froze on pi2: btcmon held an ESTABLISHED connection to Coinbase's edge forever because nothing had a timeout, so the checker blocked on it permanently — no error, no STALE, just a frozen price.

- reqwest clients for price and fees now time out at 10 s
- checker loops wrap fetches in `tokio::time::timeout` (15 s) and surface `timed out` as the error state